### PR TITLE
Bump go version to 1.14 and Use the entrypoint instead of the cmd in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.4 as builder
+FROM golang:1.14.7 as builder
 
 WORKDIR $GOPATH/src/github.com/yahoo/k8s-athenz-syncer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apk --update add ca-certificates
 
 COPY --from=builder /go/bin/k8s-athenz-syncer /usr/bin/k8s-athenz-syncer
 
-CMD ["/usr/bin/k8s-athenz-syncer"]
+ENTRYPOINT ["/usr/bin/k8s-athenz-syncer"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yahoo/k8s-athenz-syncer
 
-go 1.12
+go 1.14
 
 require (
 	github.com/ardielle/ardielle-go v1.5.2


### PR DESCRIPTION
I bumped go version to 1.14, and updated Dockerfile to use the `ENTRYPOINT` instead of the `CMD` in according with the following best practices.

> The best use for ENTRYPOINT is to set the image’s main command, allowing that image to be run as though it was that command (and then use CMD as the default flags).

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint