### PR TITLE
Add flags to specify the ConfigMap to record the latest time that the Update Cron contacted Athenz

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/yahoo/k8s-athenz-syncer/pkg/controller"
+	"github.com/yahoo/k8s-athenz-syncer/pkg/cron"
 	"github.com/yahoo/k8s-athenz-syncer/pkg/crypto"
 	"github.com/yahoo/k8s-athenz-syncer/pkg/identity"
 	"github.com/yahoo/k8s-athenz-syncer/pkg/util"
@@ -94,6 +95,9 @@ func main() {
 	cert := flag.String("cert", "/var/run/athenz/service.cert.pem", "Athenz certificate file")
 	zmsURL := flag.String("zms-url", "", "Athenz ZMS API URL")
 	updateCron := flag.String("update-cron", "1m0s", "Update cron sleep time")
+	athenzContactTimeCmNs := flag.String("athenz-contact-time-cm-ns", "kube-yahoo", "Namespace of ConfigMap to record the latest time that the Update Cron contacted Athenz")
+	athenzContactTimeCmName := flag.String("athenz-contact-time-cm-name", "athenzcall-config", "Name of ConfigMap to record the latest time that the Update Cron contacted Athenz")
+	athenzContactTimeCmKey := flag.String("athenz-contact-time-cm-key", "latest_contact", "Key of ConfigMap to record the latest time that the Update Cron contacted Athenz")
 	resyncCron := flag.String("resync-cron", "1h0m0s", "Cron full resync sleep time")
 	queueDelayInterval := flag.String("queue-delay-interval", "250ms", "Delay interval time for workqueue")
 	adminDomain := flag.String("admin-domain", "", "admin domain")
@@ -187,7 +191,13 @@ func main() {
 		log.Panicf("Queue delay input is invalid. Error: %v", err)
 	}
 
-	controller := controller.NewController(k8sClient, versiondClient, zmsClient, updatePeriod, resyncPeriod, delayInterval, util)
+	cm := &cron.AthenzContactTimeConfigMap{
+		Namespace: *athenzContactTimeCmNs,
+		Name:      *athenzContactTimeCmName,
+		Key:       *athenzContactTimeCmKey,
+	}
+
+	controller := controller.NewController(k8sClient, versiondClient, zmsClient, updatePeriod, resyncPeriod, delayInterval, util, cm)
 
 	// use a channel to synchronize the finalization for a graceful shutdown
 	defer close(stopCh)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -59,7 +59,7 @@ type Controller struct {
 }
 
 // NewController returns a Controller with logger, clientset, queue and informer generated
-func NewController(k8sClient kubernetes.Interface, versiondClient athenzClientset.Interface, zmsClient *zms.ZMSClient, updateCron time.Duration, resyncCron time.Duration, delayInterval time.Duration, util *util.Util) *Controller {
+func NewController(k8sClient kubernetes.Interface, versiondClient athenzClientset.Interface, zmsClient *zms.ZMSClient, updateCron time.Duration, resyncCron time.Duration, delayInterval time.Duration, util *util.Util, cm *cron.AthenzContactTimeConfigMap) *Controller {
 	nsListWatcher := cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(), "namespaces", corev1.NamespaceAll, fields.Everything())
 	nsIndexInformer := cache.NewSharedIndexInformer(nsListWatcher, &corev1.Namespace{}, time.Hour, cache.Indexers{})
 	rateLimiter := ratelimiter.NewRateLimiter(delayInterval)
@@ -92,7 +92,7 @@ func NewController(k8sClient kubernetes.Interface, versiondClient athenzClientse
 		trustDomainIndexKey: cr.TrustDomainIndexFunc,
 	})
 	c.cr = cr.NewCRUtil(versiondClient, crIndexInformer)
-	c.cron = cron.NewCron(k8sClient, updateCron, resyncCron, "", zmsClient, nsIndexInformer, queue, util, c.cr)
+	c.cron = cron.NewCron(k8sClient, updateCron, resyncCron, "", zmsClient, nsIndexInformer, queue, util, c.cr, cm)
 	return c
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/yahoo/athenz/clients/go/zms"
 	athenz_domain "github.com/yahoo/k8s-athenz-syncer/pkg/apis/athenz/v1"
 	"github.com/yahoo/k8s-athenz-syncer/pkg/client/clientset/versioned/fake"
+	"github.com/yahoo/k8s-athenz-syncer/pkg/cron"
 	"github.com/yahoo/k8s-athenz-syncer/pkg/util"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
@@ -45,7 +46,12 @@ func newController() *Controller {
 	clientset := k8sfake.NewSimpleClientset()
 	zmsclient := zms.NewClient("https://zms.athenz.com", &http.Transport{})
 	util := util.NewUtil("admin.domain", []string{"kube-system", "kube-public", "kube-test"})
-	newCtl := NewController(clientset, athenzclientset, &zmsclient, time.Minute, time.Hour, 250*time.Millisecond, util)
+	cm := &cron.AthenzContactTimeConfigMap{
+		Namespace: "kube-yahoo",
+		Name:      "athenzcall-config",
+		Key:       "latest_contact",
+	}
+	newCtl := NewController(clientset, athenzclientset, &zmsclient, time.Minute, time.Hour, 250*time.Millisecond, util, cm)
 	return newCtl
 }
 

--- a/pkg/cron/cron_test.go
+++ b/pkg/cron/cron_test.go
@@ -59,7 +59,12 @@ func newCron() *Cron {
 		Name: "home-test",
 	}})
 	cr := cr.NewCRUtil(athenzclientset, informer)
-	return NewCron(clientset, 20*time.Second, time.Minute, etag, &zmsClient, nsIndexInformer, queue, util, cr)
+	cm := &AthenzContactTimeConfigMap{
+		Namespace: "kube-yahoo",
+		Name:      "athenzcall-config",
+		Key:       "latest_contact",
+	}
+	return NewCron(clientset, 20*time.Second, time.Minute, etag, &zmsClient, nsIndexInformer, queue, util, cr, cm)
 }
 
 func TestRequestCall(t *testing.T) {
@@ -160,7 +165,7 @@ func TestUpdateAthenzContactTime(t *testing.T) {
 	c := newCron()
 	log.InitLogger("/tmp/log/test.log", "info")
 	c.UpdateAthenzContactTime("2019-01-01T01:01:01.111Z")
-	configMap, err := c.k8sClient.CoreV1().ConfigMaps(athenzMapLoc).Get(athenzMapName, metav1.GetOptions{})
+	configMap, err := c.k8sClient.CoreV1().ConfigMaps(c.contactTimeCm.Namespace).Get(c.contactTimeCm.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -168,8 +173,8 @@ func TestUpdateAthenzContactTime(t *testing.T) {
 		t.Error("New config map created should not be nil")
 	}
 	c.UpdateAthenzContactTime("2020-02-02T01:01:01.111Z")
-	configMap, err = c.k8sClient.CoreV1().ConfigMaps(athenzMapLoc).Get(athenzMapName, metav1.GetOptions{})
-	if configMap.Data[athenzMapKey] != "2020-02-02T01:01:01.111Z" {
+	configMap, err = c.k8sClient.CoreV1().ConfigMaps(c.contactTimeCm.Namespace).Get(c.contactTimeCm.Name, metav1.GetOptions{})
+	if configMap.Data[c.contactTimeCm.Key] != "2020-02-02T01:01:01.111Z" {
 		t.Error("Failed to update the latest timestamp")
 	}
 }


### PR DESCRIPTION
I added the following flags to specify the ConfigMap to record the latest time that the Update Cron contacted Athenz.

- `-athenz-contact-time-cm-ns`
- `-athenz-contact-time-cm-name`
- `-athenz-contact-time-cm-key`

It would be useful for k8s-athenz-syncer users to be able to specify the ConfigMap.