### PR TITLE
Bump: CRD API Version `v1beta1`=>`v1`, golang `1.14.7`=>`1.25`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /workspace
+
 COPY go.mod go.sum ./
 RUN go mod download
+
 COPY . .
 
 RUN CGO_ENABLED=0 go test -v ./...
-
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o k8s-athenz-syncer .
 
-# Final stage: minimal runtime image
 FROM alpine:latest
 
 RUN apk --no-cache add ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o k8s-athen
 # Final stage: minimal runtime image
 FROM alpine:latest
 
-# Install CA certificates and timezone data (Essential for logs and HTTPS)
-RUN apk --no-cache add ca-certificates tzdata
-WORKDIR /
+RUN apk --no-cache add ca-certificates
 
+WORKDIR /
 COPY --from=builder /workspace/k8s-athenz-syncer /usr/bin/k8s-athenz-syncer
 
 # TODO: Consider using a non-root user for better security practices

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,7 @@ COPY . .
 # -o manager: Explicitly name the output binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o manager .
 
-# 2. Run Stage
-# Use a specific tag for stability rather than 'latest'
-FROM alpine:3.23
+FROM alpine:latest
 
 # Install CA certificates and timezone data (Essential for logs and HTTPS)
 RUN apk --no-cache add ca-certificates tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,25 @@
 FROM golang:1.25-alpine AS builder
 
-# Install essential packages (git is often required for fetching dependencies)
-RUN apk add --no-cache git
-
 WORKDIR /workspace
-
-# Copy dependency files first to leverage Docker cache
-# (Prevents re-downloading modules when only source code changes)
 COPY go.mod go.sum ./
 RUN go mod download
-
-# Copy source code and build
 COPY . .
 
-# -ldflags="-w -s": Strip debug information to reduce binary size
-# -o manager: Explicitly name the output binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o manager .
+RUN CGO_ENABLED=0 go test -v ./...
 
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o k8s-athenz-syncer .
+
+# Final stage: minimal runtime image
 FROM alpine:latest
 
 # Install CA certificates and timezone data (Essential for logs and HTTPS)
 RUN apk --no-cache add ca-certificates tzdata
-
 WORKDIR /
-COPY --from=builder /workspace/manager .
+
+COPY --from=builder /workspace/k8s-athenz-syncer /usr/bin/k8s-athenz-syncer
 
 # TODO: Consider using a non-root user for better security practices
 # Run as a non-root user for security best practices
 # USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/usr/bin/k8s-athenz-syncer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,34 @@
-FROM golang:1.14.7 as builder
+FROM golang:1.25-alpine AS builder
 
-WORKDIR $GOPATH/src/github.com/yahoo/k8s-athenz-syncer
+# Install essential packages (git is often required for fetching dependencies)
+RUN apk add --no-cache git
 
+WORKDIR /workspace
+
+# Copy dependency files first to leverage Docker cache
+# (Prevents re-downloading modules when only source code changes)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code and build
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go install ./... && \
-    go test ./...
+# -ldflags="-w -s": Strip debug information to reduce binary size
+# -o manager: Explicitly name the output binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o manager .
 
-FROM alpine:latest
+# 2. Run Stage
+# Use a specific tag for stability rather than 'latest'
+FROM alpine:3.23
 
-RUN apk --update add ca-certificates
+# Install CA certificates and timezone data (Essential for logs and HTTPS)
+RUN apk --no-cache add ca-certificates tzdata
 
-COPY --from=builder /go/bin/k8s-athenz-syncer /usr/bin/k8s-athenz-syncer
+WORKDIR /
+COPY --from=builder /workspace/manager .
 
-ENTRYPOINT ["/usr/bin/k8s-athenz-syncer"]
+# TODO: Consider using a non-root user for better security practices
+# Run as a non-root user for security best practices
+# USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ The Athenz Domain custom resource definition must be first created in order for 
 kubectl apply -f k8s/athenzdomain.yaml
 ```
 
+
+#### K8s Namespace
+
+The controller `k8s-athenz-syncer` must be deployed in a specific namespace. You can either use an existing namespace or create a new one. For this instruction, we will use the namespace `kube-yahoo`. Run the following command:
+
+```sh
+kubectl create ns kube-yahoo
+```
+
 #### Service Account
 In order to tell SIA which service to provide an X.509 certificate to, a service account must be present. This is required for the controller to authenticate with ZMS for api calls. Run the following command:
 ```
@@ -130,7 +139,7 @@ kubectl apply -f k8s/serviceaccount.yaml
 ```
 or
 ```
-kubectl create serviceaccount k8s-athenz-syncer
+kubectl create serviceaccount k8s-athenz-syncer -n kube-yahoo
 ```
 
 #### ClusterRole and ClusterRoleBinding

--- a/k8s/athenzdomain.yaml
+++ b/k8s/athenzdomain.yaml
@@ -1,14 +1,18 @@
 kind: CustomResourceDefinition
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 metadata:
   name: athenzdomains.athenz.io
 spec:
   group: athenz.io
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # Ignore unknown fields in the AthenzDomain spec, as it could be a bit complex:
+        x-kubernetes-preserve-unknown-fields: true
   scope: Cluster
   names:
     plural: athenzdomains
-    singular: athenzdomain
-    kind: AthenzDomain
-    shortNames:
-    - domain

--- a/k8s/athenzdomain.yaml
+++ b/k8s/athenzdomain.yaml
@@ -16,3 +16,7 @@ spec:
   scope: Cluster
   names:
     plural: athenzdomains
+    singular: athenzdomain
+    kind: AthenzDomain
+    shortNames:
+    - domain


### PR DESCRIPTION
# Issue

While attempting to deploy this repository, I found that some parts were too outdated to work. I've updated them to fix the deployment process. I also noticed some indentation issues in the documentation, but I'll handle those in a follow-up PR.

# What's done?

- Bump `apiVersion` of `CustomResourceDefinition`: `v1beta1` => `v1` : `v1beta1` is removed from kubernetes version 1.22 ([ref](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122)) 
- Bump base image `golang:1.14.7` => `golang:1.25-alpine`
- Docker layer caching for smaller/more secure binary

# Operation Check

Created a Kubernetes namespace `home-syncer` & Verified that the syncer successfully generated the `AthenzDomain` resource, with its roles and policies correctly synced:

![03](https://github.com/user-attachments/assets/1a734b35-a935-4a3e-a308-d4c2cd09b874)

